### PR TITLE
Fix ESLint warning in App.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { ChevronRight, Clock, TrendingUp, CheckCircle, Zap, Eye, Download, Mail, ArrowDownCircle, X as XIcon, Sparkles, Loader2, HelpCircle, Cpu, AlertTriangle } from 'lucide-react';
+import { ChevronRight, Clock, TrendingUp, CheckCircle, Zap, Eye, Download, Mail, ArrowDownCircle, X as XIcon, Sparkles, HelpCircle, Cpu, AlertTriangle } from 'lucide-react';
 /* eslint-disable no-unused-vars */
 
 // --- Color Palette (retained for UI consistency) ---


### PR DESCRIPTION
## Summary
- remove unused `Loader2` import in `App.js`

## Testing
- `CI=true npm test --silent -- --passWithNoTests`
- `CI=true npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68427d3643488325b1d0353cf0cce8a2